### PR TITLE
prevent overwriting $? in scheduler

### DIFF
--- a/zplugin.zsh
+++ b/zplugin.zsh
@@ -1617,8 +1617,8 @@ aliases${~exts})(*) ]] && ZPLG_ICES[${match[1]}]+="${ZPLG_ICES[${match[1]}]:+;}$
 #      script, not from prompt
 #
 -zplg-scheduler() {
-    integer __ret=$?
-    [[ "$1" = "following" ]] && sched +1 "ZPLGM[underscore]=\$_; ZPLGM[printexitvalue_opt]=\$options[printexitvalue]; -zplg-scheduler following \${ZPLGM[underscore]}"
+    integer __ret=${__ret:-$?}
+    [[ "$1" = "following" ]] && sched +1 "__ret=\$?; ZPLGM[underscore]=\$_; ZPLGM[printexitvalue_opt]=\$options[printexitvalue]; -zplg-scheduler following \${ZPLGM[underscore]}"
     [[ -n "$1" && "$1" != (following*|burst) ]] && { local THEFD="$1"; zle -F "$THEFD"; exec {THEFD}<&-; }
     [[ "$1" = "burst" ]] && local -h EPOCHSECONDS=$(( EPOCHSECONDS+10000 ))
 
@@ -1680,7 +1680,7 @@ aliases${~exts})(*) ]] && ZPLG_ICES[${match[1]}]+="${ZPLG_ICES[${match[1]}]:+;}$
         # There's a bug in Zsh: first sched call would not be issued
         # until a key-press, if "sched +1 ..." would be called inside
         # zle -F handler. So it's done here, in precmd-handle code.
-        sched +1 "ZPLGM[underscore]=\$_; ZPLGM[printexitvalue_opt]=\$options[printexitvalue]; -zplg-scheduler following \${ZPLGM[underscore]}"
+        sched +1 "__ret=\$?; ZPLGM[underscore]=\$_; ZPLGM[printexitvalue_opt]=\$options[printexitvalue]; -zplg-scheduler following \${ZPLGM[underscore]}"
 
         ANFD="13371337" # for older Zsh + noclobber option
         exec {ANFD}< <(LANG=C command sleep 0.002; builtin print run;)
@@ -1692,7 +1692,7 @@ aliases${~exts})(*) ]] && ZPLG_ICES[${match[1]}]+="${ZPLG_ICES[${match[1]}]:+;}$
     for __task in "${ZPLG_RUN[@]}"; do
         -zplg-run-task 1 "${(@z)__task}" && ZPLG_TASKS+=( "$__task" )
         [[ $(( ++__idx, __count += ${${REPLY:+1}:-0} )) -gt 0 && "$1" != "burst" ]] && \
-            { 
+            {
                 ANFD="13371337" # for older Zsh + noclobber option
                 exec {ANFD}< <(LANG=C command sleep 0.002; builtin print run;)
                 command true # workaround a Zsh bug, see: http://www.zsh.org/mla/workers/2018/msg00966.html


### PR DESCRIPTION
When calling `sched` inside `-zplg-scheduler` to schedule the next scheduler call (wow, try saying that ten times fast 😵), the `$?` variable was being overwritten such that line 1620 (`integer __ret=$?`) was not storing the last return value of whatever the user had last run, but the result of the variable assignment `ZPLGM[printexitvalue_opt]=\$options[printexitvalue]`.

I didn't fully realize this until looking into it, but scalar variable assignment actually has an exit status in zsh, e.g:

```
maddy ♥ ~ » false; FOO=123; BAR=456; echo $?                                                                                                        [6:15:00]
0
maddy ♥ ~ » false; FOO=123 BAR=456; echo $?                                                                                                         [6:15:03]
0
maddy ♥ ~ » false; FOO=123 BAR=456 echo $?                                                                                                          [6:15:06]
1
```

So, in order to preserve the user's last return code, we need to save it before setting any other variables.