### PR TITLE
*autoload,*install: Restore ver-icefix, pending changes

### DIFF
--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1477,7 +1477,7 @@ ZPLGM[EXTENDED_GLOB]=""
                   )
                   [[ ${ice[atpull]} = "!"* ]] && -zplg-countdown "atpull" && ( (( ${+ice[nocd]} == 0 )) && { builtin cd -q "$local_dir" && -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; ((1)); } || -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; )
                   ZPLG_ICE=()
-                  (( !skip_pull )) && command git "${${+ice[ver]+merge}:-pull}" --no-stat ${ice[ver]}
+                  (( !skip_pull )) && command git merge --no-stat ${ice[ver]:-FETCH_HEAD}
               }
             )
         }

--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1428,7 +1428,7 @@ ZPLGM[EXTENDED_GLOB]=""
               integer had_output=0
               local IFS=$'\n'
               command git fetch --quiet && \
-                command git log --color --date=short --pretty=format:'%Cgreen%cd %h %Creset%s %Cred%d%Creset%n' ..FETCH_HEAD | \
+                command git log --color --date=short --pretty=format:'%Cgreen%cd %h %Creset%s %Cred%d%Creset%n' .."${ice[ver]:-FETCH_HEAD}" | \
                 while read line; do
                   [[ -n "${line%%[[:space:]]##}" ]] && {
                       [[ $had_output -eq 0 ]] && {
@@ -1477,14 +1477,14 @@ ZPLGM[EXTENDED_GLOB]=""
                   )
                   [[ ${ice[atpull]} = "!"* ]] && -zplg-countdown "atpull" && ( (( ${+ice[nocd]} == 0 )) && { builtin cd -q "$local_dir" && -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; ((1)); } || -zplg-at-eval "${ice[atpull]#\!}" "${ice[atclone]}"; )
                   ZPLG_ICE=()
-                  (( !skip_pull )) && command git pull --no-stat
+                  (( !skip_pull )) && command git "${${+ice[ver]+merge}:-pull}" --no-stat ${ice[ver]}
               }
             )
         }
 
         [[ -d "$local_dir/.git" ]] && \
             (  builtin cd -q "$local_dir" # || return 1 - don't return, maybe it's some hook's logic
-               command git pull --recurse-submodules
+               command git submodule update --init --recursive
             )
 
         local -a log
@@ -1535,7 +1535,7 @@ ZPLGM[EXTENDED_GLOB]=""
                 "${arr[5]}" "plugin" "$user" "$plugin" "$id_as" "$local_dir" atpull
             done
             ZPLG_ICE=()
-        }
+        } || { [[ ${ICE_OPTS[opt_-q,--quiet]} != 1 && -z ${ice[is_release]} ]] && print "Already up to date." }
 
         # Store ices to disk at update of plugin
         -zplg-store-ices "$local_dir/._zplugin" ice "" "" "" ""

--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1382,9 +1382,9 @@ ZPLGM[EXTENDED_GLOB]=""
         if [[ -n "${ice[is_release]}" ]] {
             (( ${+functions[-zplg-setup-plugin-dir]} )) || builtin source ${ZPLGM[BIN_DIR]}"/zplugin-install.zsh"
             -zplg-get-latest-gh-r-version "$user" "$plugin"
-            if [[ "${ice[is_release]}" = $REPLY ]] {
+            if [[ "${ice[is_release]}" = *$REPLY* ]] {
                 [[ "${ICE_OPTS[opt_-q,--quiet]}" != 1 ]] && \
-                    print -- "\rBinary release already up to date (version: ${REPLY/(#b)(\/[^\/]##)(#c4,4)\/([^\/]##)*/${match[2]}})"
+                    print -- "\rBinary release already up to date (version: ${${+ice[ver]+${REPLY/(#b)(\/[^\/]##)(#c4,4)\/([^\/]##)*/${match[2]}}}:-$REPLY})"
 
                 (( ${+ice[run-atpull]} )) && { do_update=1; skip_pull=1; }
             } else {

--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1381,7 +1381,7 @@ ZPLGM[EXTENDED_GLOB]=""
         local do_update=0 skip_pull=0
         if [[ -n "${ice[is_release]}" ]] {
             (( ${+functions[-zplg-setup-plugin-dir]} )) || builtin source ${ZPLGM[BIN_DIR]}"/zplugin-install.zsh"
-            -zplg-get-latest-gh-r-version "$user" "$plugin"
+            -zplg-get-latest-gh-r-version "$user" "$plugin" "${ice[ver]}"
             if [[ "${ice[is_release]}" = *$REPLY* ]] {
                 [[ "${ICE_OPTS[opt_-q,--quiet]}" != 1 ]] && \
                     print -- "\rBinary release already up to date (version: ${${+ice[ver]+${REPLY/(#b)(\/[^\/]##)(#c4,4)\/([^\/]##)*/${match[2]}}}:-$REPLY})"

--- a/zplugin-autoload.zsh
+++ b/zplugin-autoload.zsh
@@ -1382,9 +1382,9 @@ ZPLGM[EXTENDED_GLOB]=""
         if [[ -n "${ice[is_release]}" ]] {
             (( ${+functions[-zplg-setup-plugin-dir]} )) || builtin source ${ZPLGM[BIN_DIR]}"/zplugin-install.zsh"
             -zplg-get-latest-gh-r-version "$user" "$plugin"
-            if [[ "${ice[is_release]}" = */$REPLY/* ]] {
+            if [[ "${ice[is_release]}" = $REPLY ]] {
                 [[ "${ICE_OPTS[opt_-q,--quiet]}" != 1 ]] && \
-                    print -- "\rBinary release already up to date (version: $REPLY)"
+                    print -- "\rBinary release already up to date (version: ${REPLY/(#b)(\/[^\/]##)(#c4,4)\/([^\/]##)*/${match[2]}})"
 
                 (( ${+ice[run-atpull]} )) && { do_update=1; skip_pull=1; }
             } else {

--- a/zplugin-install.zsh
+++ b/zplugin-install.zsh
@@ -936,7 +936,7 @@ builtin source ${ZPLGM[BIN_DIR]}"/zplugin-side.zsh"
     local user="${reply[-2]}"
     local plugin="${reply[-1]}"
 
-    local url="https://github.com/$user/$plugin/releases/latest"
+    local url="https://github.com/$user/$plugin/releases/${ice[ver]:-latest}"
 
     local -a list
     list=( ${(@f)"$( { -zplg-download-file-stdout $url || -zplg-download-file-stdout $url 1; } 2>/dev/null | \

--- a/zplugin-install.zsh
+++ b/zplugin-install.zsh
@@ -938,11 +938,35 @@ builtin source ${ZPLGM[BIN_DIR]}"/zplugin-side.zsh"
 
     local url="https://github.com/$user/$plugin/releases/${ice[ver]:-latest}"
 
-    local -a list
+    local -A matchstr=(
+        "i386"    "(386|686)"
+        "i686"    "(386|686)"
+        "x86_64"  "(x86_64|amd64|intel)"
+        "amd64"   "(x86_64|amd64|intel)"
+        "aarch64" "aarch64"
+        "linux"   "(linux|linux-gnu)"
+        "darwin"  "(darwin|macos|mac-os|osx|os-x)"
+        "cygwin"  "(windows|cygwin)"
+        "windows" "(windows|cygwin)"
+    )
+
+    local -a list list2
     list=( ${(@f)"$( { -zplg-download-file-stdout $url || -zplg-download-file-stdout $url 1; } 2>/dev/null | \
                   command grep -o 'href=./'$user'/'$plugin'/releases/download/[^"]\+')"} )
 
-    list=( "${(uOn)list[@]/(#b)href=?(\/[^\/]##)(#c4,4)\/([^\/]##)*/${match[2]}}" )
+    list=( "${list[@]#href=?}" )
+    [[ -n "${ice[bpick]}" ]] && list=( "${(M)list[@]:#(#i)*/${~ice[bpick]}}" )
+
+    [[ ${#list} -gt 1 ]] && {
+        list2=( "${(M)list[@]:#(#i)*${~matchstr[$CPUTYPE]:-${CPUTYPE#(#i)(i|amd)}}*}" )
+        [[ ${#list2} -gt 0 ]] && list=( "${list2[@]}" )
+    }
+
+    [[ ${#list} -gt 1 ]] && {
+        list2=( "${(M)list[@]:#(#i)*${~matchstr[${${OSTYPE%(#i)-gnu}%%(-|)[0-9.]##}]:-${${OSTYPE%(#i)-gnu}%%(-|)[0-9.]##}}*}" )
+        [[ ${#list2} -gt 0 ]] && list=( "${list2[@]}" )
+    }
+
     REPLY="${list[1]}"
 }
 # }}}

--- a/zplugin-install.zsh
+++ b/zplugin-install.zsh
@@ -935,13 +935,14 @@ builtin source ${ZPLGM[BIN_DIR]}"/zplugin-side.zsh"
     -zplg-any-to-user-plugin "$1" "$2"
     local user="${reply[-2]}"
     local plugin="${reply[-1]}"
+    [[ -n $3 ]] && integer detailed=1 || integer detailed=0
 
-    local url="https://github.com/$user/$plugin/releases/${ice[ver]:-latest}"
+    local url="https://github.com/$user/$plugin/releases/${${${detailed#0}:+${ice[ver]}}:-latest}"
 
     local -a list
     list=( ${(@f)"$( { -zplg-download-file-stdout $url || -zplg-download-file-stdout $url 1; } 2>/dev/null | \
                   command grep -o 'href=./'$user'/'$plugin'/releases/download/[^"]\+')"} )
-    [[ -n ${ice[ver]} ]] && {
+    (( detailed )) && {
         local -A matchstr=(
         "i386"    "(386|686)"
         "i686"    "(386|686)"


### PR DESCRIPTION
Referencing original pull request: #211 

Reasoning for the following changes:

https://github.com/zdharma/zplugin/blob/f2043f6e4e72243f6a767465b8bc588a0cb2c2c3/zplugin-autoload.zsh#L1431
`..FETCH_HEAD` changed to `.."${ice[ver]:-FETCH_HEAD}"`

- When the ver-ice isn't present, this functions as expected.
- When the ver-ice is used in conjunction with the `from"gh-r"` ice, this section of code is never reached, the ver-ice has different functionality.
- When the ver-ice checks out a specific branch, this should show any updates for that branch.
- When the ver-ice checks out a specific commit, this will show up as empty as there won't be any updates between the checked out commit and the commit specified by the ver-ice. This last scenario can be changed, I believed it would be beneficial to not show the log as the user checked out the commit for a reason and wouldn't need to see updates. Otherwise, they would see an increasing log every time they updated the plugin which could get to be quite long depending on how far behind their checked out commit is. Maybe this could be rewritten to indicate there are pending updates without showing the full log. This is related to https://github.com/zdharma/zplugin/pull/211#issuecomment-557880324
>	git log to `ver` isn't going to work – it'll do just that, show commits from current version to current version,

--------------------------------------------------------

https://github.com/zdharma/zplugin/blob/f2043f6e4e72243f6a767465b8bc588a0cb2c2c3/zplugin-autoload.zsh#L1480
`git pull --no-stat` changed to `git merge --no-stat ${ice[ver]:-FETCH_HEAD}`

A git pull consist of a git fetch and a git merge. [(From what I understand)](https://guide.freecodecamp.org/git/git-pull/). Since you perform a git fetch prior to this point we can use git merge and what it's syntax allows.
- When the ver-ice isn't present, this merges all changes up to FETCH_HEAD (previous behavior)
- When the ver-ice is used in conjunction with the `from"gh-r"` ice, this section of code is never reached, the ver-ice has different functionality.
- When the ver-ice checks out a specific branch, this should merge all the latest changes for that branch
- When the ver-ice checks out a specific commit, this keeps the plugin at that commit.

This is related to https://github.com/zdharma/zplugin/pull/211#issuecomment-557880324
>	the check on the merge/pull git subcommand was using `ZPLG_ICE`, while it should be using `ice`

I've now changed it to use `ice`

----------------------------------------------------------

https://github.com/zdharma/zplugin/blob/f2043f6e4e72243f6a767465b8bc588a0cb2c2c3/zplugin-autoload.zsh#L1487

`git pull --recurse-submodules` changed to `git submodule update --init --recursive`

The issue in #164 was that the original code ran `git submodule foreach git pull origin master`, which pulled updates for each submodule past the point they existed in the cloned repo. This was replaced with `git pull --recurse-submodules` which fixed this behavior. I had to replace this command because it would update plugins that used the ver-ice to check out a specific commits, past this specified commit. Since prior to this point you already merge any changes I found the git pull aspect was unnecessary and opted for `git submodule update --init --recursive` which functions to same as `git pull --recurse-submodules` just without updating the cloned repo past the checked out commit.

This is related to https://github.com/zdharma/zplugin/pull/211#issuecomment-557880324
>     the commits caused a duplicate message about up to date repo.
I believe this was caused by the reintroduction of `git pull --recurse-submodules` in https://github.com/zdharma/zplugin/commit/7583e9268644e59c5a9ee34c512fec157cf188e3 which doesn't exit silently, but I don't believe this is needed with the new command.

------------------------------------------------------------

https://github.com/zdharma/zplugin/blob/f2043f6e4e72243f6a767465b8bc588a0cb2c2c3/zplugin-autoload.zsh#L1495-L1538
Added `|| { [[ ${ICE_OPTS[opt_-q,--quiet]} != 1 && -z ${ice[is_release]} ]] && print "Already up to date." }` which prints "Already up to date." if no updates were found, the --quiet arg isnt passed, and the plugin isn't a release. This was previously provided by `git pull --recurse-submodules`. The new command finishes silently, thus the need to add this print.

----------------------------------------------------------------

https://github.com/zdharma/zplugin/blob/f2043f6e4e72243f6a767465b8bc588a0cb2c2c3/zplugin-install.zsh#L939

`latest` changed to `${ice[ver]:-latest}` in url

When a tag is specified to use for a release, Zplugin downloads the correct release based on this tag. But when Zplugin update was run this line would indicate there was a newer release, causing zplugin to redownload the release. This change simply makes Zplugin compare the downloaded version to the tag originally specified.