### PR TITLE
add chmod command if directory needed creation

### DIFF
--- a/doc/install.sh
+++ b/doc/install.sh
@@ -73,8 +73,8 @@ cat <<-EOF >> "$THE_ZDOTDIR/.zshrc"
 ### Added by Zinit's installer
 if [[ ! -f $ZINIT_HOME/$ZINIT_BIN_DIR_NAME/zinit.zsh ]]; then
     print -P "%F{33}▓▒░ %F{220}Installing DHARMA Initiative Plugin Manager (zdharma/zinit)…%f"
-    command mkdir -p $ZINIT_HOME
-    command git clone https://github.com/zdharma/zinit $ZINIT_HOME/$ZINIT_BIN_DIR_NAME && \\
+    command mkdir -p "$ZINIT_HOME" && command chmod g-rwX "$ZINIT_HOME"
+    command git clone https://github.com/zdharma/zinit "$ZINIT_HOME/$ZINIT_BIN_DIR_NAME" && \\
         print -P "%F{33}▓▒░ %F{34}Installation successful.%f" || \\
         print -P "%F{160}▓▒░ The clone has failed.%f"
 fi


### PR DESCRIPTION
for auto-installed zinit, the homedir needs group perms off or else compaudit will complain at every step
also add quotes in case a naughty user uses spaces