### PR TITLE
On Windows, the BusyBox executable can be busybox.exe

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -684,7 +684,7 @@ ZINIT[EXTENDED_GLOB]=""
 # BusyBox less lacks the -X and -i options, so it can use more
 .zinit-pager() {
     setopt LOCAL_OPTIONS EQUALS
-    if [[ ${${:-=less}:A:t} = 'busybox' ]]; then
+    if [[ ${${:-=less}:A:t} = busybox* ]]; then
         more
     else
         less -FRXi


### PR DESCRIPTION
When checking to see if `less` is really `busybox`, we have to consider that in some Windows environments (such as the MobaXterm Terminal), the BusyBox executable can be `busybox.exe`.