### PR TITLE
*install,*autoload: Consolidate gh-r version logic

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1465,10 +1465,10 @@ ZINIT[EXTENDED_GLOB]=""
         if [[ -n ${ice[is_release]} ]] {
             (( ${+functions[.zinit-setup-plugin-dir]} )) || builtin source ${ZINIT[BIN_DIR]}"/zinit-install.zsh"
             .zinit-get-latest-gh-r-version "$user" "$plugin"
-            local version=$REPLY
-            if [[ ${ice[is_release]} = */$version/* ]] {
+            local version=${REPLY/(#b)(\/[^\/]##)(#c4,4)\/([^\/]##)*/${match[2]}}
+            if [[ ${ice[is_release]} = *$REPLY* ]] {
                 (( !ICE_OPTS[opt_-q,--quiet] )) && \
-                    print -- "\rBinary release already up to date (version: $REPLY)"
+                    print -- "\rBinary release already up to date (version: $version)"
                 skip_pull=1
                 (( ${+ice[run-atpull]} )) && { do_update=1; }
             } else {


### PR DESCRIPTION
This consolidates all the matching logic into the `.zinit-get-latest-gh-r-version` function where it's reply can be used in both `.zinit-setup-plugin-dir` and `.zinit-update-or-status`. This is my go at it anyways to give a start to the function described here: https://github.com/zdharma/zinit/pull/232#issuecomment-575440083

Currently `Binary release already up to date` is still printed if `[[ ${#list} -eq 0 ]]`. I haven't looked at hiding it conditionally.

This is a resubmit of #261