### PR TITLE
shadow-autoload breaks under rcexpandparam

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -190,7 +190,7 @@ builtin setopt noaliases
 # run custom `autoload' function, that doesn't need FPATH.
 :zinit-shadow-autoload () {
     builtin setopt localoptions noerrreturn noerrexit extendedglob warncreateglobal \
-        typesetsilent noshortloops unset
+        norcexpandparam typesetsilent noshortloops unset
     local -a opts
     local func
 


### PR DESCRIPTION
I setopt rcexpandparam in my zshrc and all hell broke loose.

[Here is one example after editing a single plugin's autoload call to the following](http://ix.io/2dv9) 

```zsh
(){
    setopt localoptions rcexpandparam
    set -x
    autoload -Uz ...
    set +x
}
```