### PR TITLE
Fix checking the plugin existence when `zinit update` and `from'gh-r'`

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -291,11 +291,11 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh"
     local user=$1 plugin=$2 id_as=$3 remote_url_path=${1:+$1/}$2 \
         local_path tpe=$4 update=$5 version=$6
 
-    .zinit-get-object-path plugin "$id_as" && \
-        { print -Pr "$ZINIT[col-msg2]A plugin named $ZINIT[col-obj]$id_as" \
+    if .zinit-get-object-path plugin "$id_as" && [[ $tpe != release ]]; then
+        print -Pr "$ZINIT[col-msg2]A plugin named $ZINIT[col-obj]$id_as" \
             "$ZINIT[col-msg2]already exists, aborting.%f%b"
-          return 1
-        }
+        return 1
+    fi
     local_path=$reply[-3]
 
     local -A sites


### PR DESCRIPTION
When try to update the plugins downloaded from GitHub Releases, can't update it and the message is displayed as below. This PR fixes updating the plugins when `from'gh-r'`.

```sh
> zinit ice lucid wait'0' from'gh-r' as'program' pick'ripgrep*/rg'
> zinit light BurntSushi/ripgrep
> zinit update BurntSushi/ripgrep
A plugin named BurntSushi/ripgrep already exists, aborting.
```

I'm sorry for my unskillful English.