### PR TITLE
Fix completions installation condition

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -521,7 +521,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { print -P "${ZINIT[col-err
     # After additional executions like atclone'' - install completions (1 - plugins)
     local -A ICE_OPTS
     ICE_OPTS[opt_-q,--quiet]=1
-    [[ 0 = ${+ZINIT_ICE[nocompletions]} || ${ZINIT_ICE[as]} != null ]] && \
+    [[ 0 = ${+ZINIT_ICE[nocompletions]} && ${ZINIT_ICE[as]} != null ]] && \
         .zinit-install-completions "$id_as" "" "0"
 
     if [[ -e /tmp/zinit.skipped_comps.$$.lst || -e /tmp/zinit.installed_comps.$$.lst ]] {
@@ -1310,7 +1310,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { print -P "${ZINIT[col-err
     # After additional executions like atclone'' - install completions (2 - snippets)
     local -A ICE_OPTS
     ICE_OPTS[opt_-q,--quiet]=1
-    [[ 0 = ${+ZINIT_ICE[nocompletions]} || ${ZINIT_ICE[as]} != null ]] && \
+    [[ 0 = ${+ZINIT_ICE[nocompletions]} && ${ZINIT_ICE[as]} != null ]] && \
         .zinit-install-completions "%" "$local_dir/$dirname" 0
 
     if [[ -e /tmp/zinit.skipped_comps.$$.lst || -e /tmp/zinit.installed_comps.$$.lst ]] {


### PR DESCRIPTION
Recently zinit started installing completions event if `nocompletions` ice is specified. This seems to be related to recent commit https://github.com/zdharma/zinit/commit/a46f97e8c37c51f63788599a2b2870f6f7c7a39e

With that change, if either `nocompletions` or `as"null"` ices are not specified then completions are installed, so to avoid completions installation one has to specify both `nocompletions` _and_ `as"null"`.

This commit changes logic to be equivalent to what was before.