### PR TITLE
Hide internal function arguments from sourced scripts

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -1182,7 +1182,10 @@ builtin setopt noaliases
 # $2 - plugin
 # $3 - mode (light or load)
 .zinit-load-plugin() {
-    local ___user="$1" ___plugin="$2" ___id_as="$3" ___mode="$4" ___correct=0 ___retval=0
+    local ___user="$1" ___plugin="$2" ___id_as="$3" ___mode="$4" ___rst="$5" ___correct=0 ___retval=0
+    # Hide arguments from sourced scripts. Without this calls our "$@" are visible as "$@"
+    # within scripts that we `source`.
+    set --
     ZINIT[CUR_USR]="$___user" ZINIT[CUR_PLUGIN]="$___plugin" ZINIT[CUR_USPL2]="$___id_as"
     [[ -o ksharrays ]] && ___correct=1
 
@@ -1326,7 +1329,7 @@ builtin setopt noaliases
     # Mark no load is in progress
     ZINIT[CUR_USR]= ZINIT[CUR_PLUGIN]= ZINIT[CUR_USPL2]=
 
-    (( $5 )) && { print; zle .reset-prompt; }
+    (( ___rst )) && { print; zle .reset-prompt; }
 
     if [[ -n $___m_bkp ]] {
         functions[m]="$___m_bkp"
@@ -1345,6 +1348,9 @@ builtin setopt noaliases
     local -a opts
     zparseopts -E -D -a opts f -command || { +zinit-message "Incorrect options (accepted ones: -f, --command)"; return 1; }
     local url="$1"
+    # Hide arguments from sourced scripts. Without this calls our "$@" are visible as "$@"
+    # within scripts that we `source`.
+    set --
     integer correct retval exists
     [[ -o ksharrays ]] && correct=1
 


### PR DESCRIPTION
When manually sourcing a file from `.zshrc`, `$@` is empty during the evaluation of the file. However, when sourcing the same file via `zinit snippet`, `zinit light` or `zinit load`, `$@` are those
of the internal `zinit` function that happens to invoke `source`. This PR sets `$@` to empty before sourcing scripts to make sourcing of files via `zinit` consistent with manual sourcing.

### Test case

```text
% cat ~/.zshrc
source ~/.zinit/bin/zinit.zsh
source ~/plugin.zsh
zinit snippet ~/plugin.zsh
% cat ~/plugin.zsh
print -lr -- start "$@" end
```

### Without this PR

```text
% zsh
start
end
 start
/home/romka/plugin.zsh
end
```

### With this PR

```text
% zsh
start
end
start
end
```

### Motivation

Some zsh scripts allow additional arguments to be passed when they are being sourced.

```zsh
source ~/plugin.zsh foo bar
```

Sourcing such scripts via `zinit` is currently impossible. It would be perfect if `zinit` allowed custom arguments to be passed to sourced scripts. This PR doesn't go that far but at least it allows passing no arguments.