### PR TITLE
Avoid git -C for compatibility with older versions

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -419,7 +419,9 @@ builtin source ${ZINIT[BIN_DIR]}"/zinit-side.zsh"
             esac
 
             if [[ -n ${ZINIT_ICE[ver]} ]] {
-                command git -C "$local_path" checkout "${ZINIT_ICE[ver]}"
+                local cur_path="$PWD"
+                cd "$local_path" && command git checkout "${ZINIT_ICE[ver]}"
+                cd "$cur_path"
             }
         }
 


### PR DESCRIPTION
A user of [my dotfiles](https://github.com/agkozak/dotfiles) has pointed out that [Zinit doesn't work at all well on CentOS Linux release 7.8.2003 (Core)](https://github.com/agkozak/dotfiles/issues/2), which uses `git` v1.8.3.1 and `zsh` v5.0.2 (I think you've run across [other problems with the latter](https://github.com/zdharma/zinit/issues/310)).

I'm proposing a workaround for `git -C`, which was not introduced until `git` v1.8.5. There is at least one other problem, which I will bring up in a separate pull request or issue.