### PR TITLE
option to use git.io to shorten raw githubusercontent urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,7 +708,7 @@ read it to get the most out of Zinit.
 The easiest way to install Zinit is to execute:
 
 ```zsh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/zdharma/zinit/master/doc/install.sh)"
+sh -c "$(curl -fsSL https://git.io/zinit_install)"
 ```
 
 This will install Zinit in `~/.zinit/bin`. `.zshrc` will be updated with three

--- a/README.md
+++ b/README.md
@@ -1238,7 +1238,7 @@ To install just the binary Zinit module **standalone** (Zinit is not needed, the
 other plugin manager), execute:
 
 ```zsh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/zdharma/zinit/master/doc/mod-install.sh)"
+sh -c "$(curl -fsSL https://git.io/zinit_mod_install)"
 ```
 
 This script will display what to add to `~/.zshrc` (2 lines) and show usage instructions.


### PR DESCRIPTION
I created a git.io short url for the install script, in case you wanted to use it in the documentation. ([gist](https://gist.github.com/dikiaap/01f5e2ba3c738012aef0a8f524a6e207) with example curl to customize)

**Why do it:** Easy to remember, easy to read
**Why not:** It's not direct

#### Shortening additional urls
Each url only gets one git.io url that can't be changed. I didn't realize this when I first made one on git.io, which made  [git.io/JvOC8](https://git.io/JvOC8) for install.sh.

I used `?` at the end to make the url unique for a new gitio link.

Edit:
Also added `?` to the mod-install.sh gitio url to leave open the possibility to customize the normal url.
