### PR TITLE
Add `pull.rebase=false` on cloning git repo

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -417,7 +417,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT
                             "$local_path" \
                             --config transfer.fsckobjects=false \
                             --config receive.fsckobjects=false \
-                            --config fetch.fsckobjects=false
+                            --config fetch.fsckobjects=false \
+                            --config pull.rebase=false
                             integer retval=$?
                             unfunction :zinit-git-clone 
                             return $retval


### PR DESCRIPTION
Fix this issue: https://github.com/zdharma/zinit/issues/345
I use `git config --global pull.rebase=interactive` but it breaks `zinit update` since interactive rebase requires user I/O. This PR will make zinit plugins be independant to the global `pull.rebase` option.