### PR TITLE
Don't expand aliases when compiling to zwc

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -737,12 +737,12 @@ ZINIT[EXTENDED_GLOB]=""
         +zinit-message "Compiling Zinit (zcompile){…}"
     }
     command rm -f $ZINIT[BIN_DIR]/*.zwc(DN)
-    zcompile $ZINIT[BIN_DIR]/zinit.zsh
-    zcompile $ZINIT[BIN_DIR]/zinit-side.zsh
-    zcompile $ZINIT[BIN_DIR]/zinit-install.zsh
-    zcompile $ZINIT[BIN_DIR]/zinit-autoload.zsh
-    zcompile $ZINIT[BIN_DIR]/zinit-additional.zsh
-    zcompile $ZINIT[BIN_DIR]/git-process-output.zsh
+    zcompile -U $ZINIT[BIN_DIR]/zinit.zsh
+    zcompile -U $ZINIT[BIN_DIR]/zinit-side.zsh
+    zcompile -U $ZINIT[BIN_DIR]/zinit-install.zsh
+    zcompile -U $ZINIT[BIN_DIR]/zinit-autoload.zsh
+    zcompile -U $ZINIT[BIN_DIR]/zinit-additional.zsh
+    zcompile -U $ZINIT[BIN_DIR]/git-process-output.zsh
     # Load for the current session
     [[ $1 != -q ]] && +zinit-message "Reloading Zinit for the current session{…}"
     source $ZINIT[BIN_DIR]/zinit.zsh
@@ -3148,7 +3148,7 @@ EOF
         for i in "${ZINIT_STRESS_TEST_OPTIONS[@]}"; do
             builtin setopt "$i"
             builtin print -n "Stress-testing ${fname:t} for option $i "
-            zcompile -R "$fname" 2>/dev/null && {
+            zcompile -UR "$fname" 2>/dev/null && {
                 builtin print "[${ZINIT[col-success]}Success${ZINIT[col-rst]}]"
             } || {
                 builtin print "[${ZINIT[col-failure]}Fail${ZINIT[col-rst]}]"
@@ -3158,7 +3158,7 @@ EOF
     )
 
     command rm -f "${fname}.zwc"
-    (( compiled )) && zcompile "$fname"
+    (( compiled )) && zcompile -U "$fname"
 } # ]]]
 # FUNCTION: .zinit-list-compdef-replay [[[
 # Shows recorded compdefs (called by plugins loaded earlier).

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -840,14 +840,14 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT
         if [[ -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} ]] {
             () {
                 builtin emulate -LR zsh -o extendedglob
-                if { ! zcompile "$first" } {
+                if { ! zcompile -U "$first" } {
                     +zinit-message "{msg2}Warning:{rst} Compilation failed. Don't worry, the plugin will work also without compilation."
                     +zinit-message "{msg2}Warning:{rst} Consider submitting an error report to Zinit or to the plugin's author."
                 } else {
                     +zinit-message " {ok}OK{rst}."
                 }
                 # Try to catch possible additional file
-                zcompile "${${first%.plugin.zsh}%.zsh-theme}.zsh" 2>/dev/null
+                zcompile -U "${${first%.plugin.zsh}%.zsh-theme}.zsh" 2>/dev/null
             }
         }
     }
@@ -867,7 +867,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT
             for first in $list; do
                 () {
                     builtin emulate -LR zsh -o extendedglob
-                    zcompile "$first"; retval+=$?
+                    zcompile -U "$first"; retval+=$?
                 }
             done
             builtin print -rl -- ${list[@]#$plugin_dir/} >! /tmp/zinit.compiled.$$.lst
@@ -1016,7 +1016,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT
                         ]] {
                             () {
                                 builtin emulate -LR zsh -o extendedglob
-                                zcompile "${list[1]}" &>/dev/null || \
+                                zcompile -U "${list[1]}" &>/dev/null || \
                                     +zinit-message "{error}Warning:{rst} couldn't compile \`{file}${list[1]}{rst}'."
                             }
                         }
@@ -1103,7 +1103,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT
                 ]] {
                     () {
                         builtin emulate -LR zsh -o extendedglob
-                        if ! zcompile "$file_path" 2>/dev/null; then
+                        if ! zcompile -U "$file_path" 2>/dev/null; then
                             builtin print -r "Couldn't compile \`${file_path:t}', it MIGHT be wrongly downloaded"
                             builtin print -r "(snippet URL points to a directory instead of a file?"
                             builtin print -r "to download directory, use preceding: zinit ice svn)."


### PR DESCRIPTION
This PR adds `-U` option to all `zcompile` call in zinit.

Reasons:
1. A standalone zsh plugin is not expected to rely on user alias to work.
2. It can prevent plugins from polluting by user alias. See https://github.com/Aloxaf/fzf-tab/issues/109
3. This is consistent with zmodules's behavior:
https://github.com/zdharma/zinit/blob/f630c3a9b4909eee329df0f949f045f9dc320d51/zmodules/Src/zdharma/zplugin.c#L859-L866
