### PR TITLE
Prevent duplicate lines being added to .zshrc

### DIFF
--- a/doc/install.sh
+++ b/doc/install.sh
@@ -117,11 +117,11 @@ echo "[38;5;219m▓▒░[0m Would you like to add 4 useful plugins" \
         echo "[34m▓▒░[0m Done (skipped the annexes chunk)."
         echo
     fi
-fi
 
-command cat <<-EOF >> "$THE_ZDOTDIR/.zshrc"
+    command cat <<-EOF >> "$THE_ZDOTDIR/.zshrc"
 ### End of Zinit's installer chunk
 EOF
+fi
 
 command cat <<-EOF
 


### PR DESCRIPTION
Currently the bit that adds `### End of Zinit's installer chunk` to zshrc lives outside the if guard that checks for existing zinit lines  (i.e. only add lines  to zshrc if `$RCUPDATE -eq 1`).

This means that duplicate lines will be added if the install script is run multiple times (which I assume is unintended).

This PR moves the this write into the if block.