### PR TITLE
zinit-message zsh 5.0.x compatibility

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -1853,8 +1853,8 @@ builtin setopt noaliases
     local -a msg
     msg=( ${${@//(#b)([\\]([\{]([^\}]##)[\}])|([\{]([^\}]##)[\}])([^\{\\]#))/$match[2]${\
 ${functions[.zinit-formatter-$match[5]]:+${\
-$(.zinit-formatter-$match[5] "$match[6]"; builtin print -rn -- $REPLY):-←↓→↑}}:-\
-${ZINIT[col-$match[5]]-$match[4]}$match[6]}}//←↓→↑} )
+$(.zinit-formatter-$match[5] "$match[6]"; builtin print -rn -- $REPLY):-←↓→}}:-\
+${ZINIT[col-$match[5]]-$match[4]}$match[6]}}//←↓→} )
     builtin print -Pr ${opt:#--} -- ${msg[1]:#--} ${msg[2,-1]}
 }
 # ]]]


### PR DESCRIPTION
That "fixes" the problem. This pull request is more to ask why?

I just removed the ↑ characters and zsh 5.0.x stops complaining...