### PR TITLE
Update zsdoc README with new name

### DIFF
--- a/zsdoc/README.md
+++ b/zsdoc/README.md
@@ -1,14 +1,14 @@
 # Code documentation
 
 Here is `Asciidoc` code documentation generated using [Zshelldoc](https://github.com/zdharma/zshelldoc).
-There are `4` Zplugin's source files, the main one is [zplugin.zsh](zplugin.zsh.adoc). The documentation
+There are `4` Zinit's source files, the main one is [zinit.zsh](zinit.zsh.adoc). The documentation
 lists all functions, interactions between them, their comments and features used.
 
 Github allows to directly view `Asciidoc` documents:
- * [zplugin.zsh](zplugin.zsh.adoc) – always loaded, in `.zshrc` ([pdf](http://zdharma.org/zplugin/zplugin.zsh.pdf))
- * [zplugin-side.zsh](zplugin-side.zsh.adoc) – common functions, loaded by `*-install` and `*-autoload` scripts ([pdf](http://zdharma.org/zplugin/zplugin-side.zsh.pdf))
- * [zplugin-install.zsh](zplugin-install.zsh.adoc) – functions used only when installing a plugin or snippet ([pdf](http://zdharma.org/zplugin/zplugin-install.zsh.pdf))
- * [zplugin-autoload.zsh](zplugin-autoload.zsh.adoc) – functions used only in interactive `Zplugin` invocations ([pdf](http://zdharma.org/zplugin/zplugin-autoload.zsh.pdf))
+ * [zinit.zsh](zinit.zsh.adoc) – always loaded, in `.zshrc` ([pdf](http://zdharma.org/zinit/zinit.zsh.pdf))
+ * [zinit-side.zsh](zinit-side.zsh.adoc) – common functions, loaded by `*-install` and `*-autoload` scripts ([pdf](http://zdharma.org/zinit/zinit-side.zsh.pdf))
+ * [zinit-install.zsh](zinit-install.zsh.adoc) – functions used only when installing a plugin or snippet ([pdf](http://zdharma.org/zinit/zinit-install.zsh.pdf))
+ * [zinit-autoload.zsh](zinit-autoload.zsh.adoc) – functions used only in interactive `Zinit` invocations ([pdf](http://zdharma.org/zinit/zinit-autoload.zsh.pdf))
 
 # PDFs, man pages, etc.
 


### PR DESCRIPTION
This commit changes links and names to reflect the name change from zplugin -> zinit.