### PR TITLE
improve gh-r version matching: foo-linux64

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1388,10 +1388,10 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT
 
     local -A matchstr
     matchstr=(
-        i386    "((386|686|x86*(#e))~*x86_64*)"
-        i686    "((386|686|x86*(#e))~*x86_64*)"
-        x86_64  "(x86_64|amd64|intel)"
-        amd64   "(x86_64|amd64|intel)"
+        i386    "((386|686|linux32|x86*(#e))~*x86_64*)"
+        i686    "((386|686|linux32|x86*(#e))~*x86_64*)"
+        x86_64  "(x86_64|amd64|intel|linux64)"
+        amd64   "(x86_64|amd64|intel|linux64)"
         aarch64 "aarch64"
         aarch64-2 "arm"
         linux   "(linux|linux-gnu)"


### PR DESCRIPTION
This handles `linux64` file versions like [jq 1.6](https://github.com/stedolan/jq/releases/tag/jq-1.6) now uses.

fixes #403
