### PR TITLE
improve gh-r version matching: macos

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1395,7 +1395,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT
         aarch64 "aarch64"
         aarch64-2 "arm"
         linux   "(linux|linux-gnu)"
-        darwin  "(darwin|mac|osx|os-x)"
+        darwin  "(darwin|mac|macos|osx|os-x)"
         cygwin  "(windows|cygwin|[-_]win|win64|win32)"
         windows "(windows|cygwin|[-_]win|win64|win32)"
         msys "(windows|msys|cygwin|[-_]win|win64|win32)"


### PR DESCRIPTION
Quick fix to allow for `macos` release matching. 

Example: `nvim-macos.tar.gz` modified in https://github.com/neovim/neovim/pull/13445