### PR TITLE
*autoload: use cd -q

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1577,7 +1577,7 @@ ZINIT[EXTENDED_GLOB]=""
             }
         }
 
-        if [[ -d $local_dir/.git ]] && ( cd $local_dir ; git show-ref --verify --quiet refs/heads/main ); then
+        if [[ -d $local_dir/.git ]] && ( cd -q $local_dir ; git show-ref --verify --quiet refs/heads/main ); then
             local main_branch=main
         else
             local main_branch=master


### PR DESCRIPTION
Everywhere else cd -q is used except here. Fixes that.