### PR TITLE
support OSTYPE linux-musl

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1478,7 +1478,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT
         }
 
         if (( $#list > 1 )) {
-            list2=( ${(M)list[@]:#(#i)*${~matchstr[${${OSTYPE%(#i)-gnu}%%(-|)[0-9.]##}]:-${${OSTYPE%(#i)-gnu}%%(-|)[0-9.]##}}*} )
+            list2=( ${(M)list[@]:#(#i)*${~matchstr[${${OSTYPE%(#i)-(gnu|musl)}%%(-|)[0-9.]##}]:-${${OSTYPE%(#i)-(gnu|musl)}%%(-|)[0-9.]##}}*} )
             (( $#list2 > 0 )) && list=( ${list2[@]} )
         }
 


### PR DESCRIPTION
Typically, when zsh is built as a static binary (as with https://github.com/romkatv/zsh-bin)
OSTYPE reports linux-musl, instead of the more common linux-gnu.
Which in turn breaks binary selection from gh-r, and leads to download of mac binaries.

This change maps both linux-gnu and linux-musl to the match string "linux".

This fixes #416